### PR TITLE
Use pip to install minepy

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,13 +2,15 @@ name: ascends
 channels:
   - bioconda
 dependencies:
- - python=3.6
- - matplotlib=3.0.3
- - numpy=1.16.4
- - pandas=0.24.2
- - tensorflow=1.13.1  
- - keras=2.2.4 
- - scikit-learn=0.20.3
- - tornado=6.0.2
- - minepy=1.2.3
- - jupyter=1.0.0
+  - python=3.6
+  - matplotlib=3.0.3
+  - numpy=1.16.4
+  - pandas=0.24.2
+  - tensorflow=1.13.1
+  - keras=2.2.4
+  - scikit-learn=0.20.3
+  - tornado=6.0.2
+  - pip
+  - jupyter=1.0.0
+  - pip:
+      - minepy==1.2.3


### PR DESCRIPTION
This PR changes the environment.yml file to include pip as a dependency, and then uses pip install minepy: minepy does not appear to be available to conda on Windows, so this was blocking install.  This PR resolves https://github.com/ornlpmcp/ASCENDS/issues/13 for me